### PR TITLE
Revise site content: update About, Portfolio, CV, author profile and navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,12 +92,6 @@ author:
   googlescholar    : "https://scholar.google.com/citations?user=pDb539YAAAAJ&hl=en"
   email            : "gfs.reboucas@gmail.com"
   linkedin         : "gfsreboucas"
-  skype			       : "gfs.reboucas"
-  orcid            : "http://orcid.org/0000-0001-7112-9512"
-  researchgate	   : "https://www.researchgate.net/profile/Geraldo_Reboucas"
-  researcherid	   : "http://www.researcherid.com/rid/O-6925-2017"
-  lattes		       : "http://lattes.cnpq.br/4451105551576597"
-  publons		       : "https://www.publons.com/a/1476057/"
   uri              :
   bitbucket        :
   codepen          :

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,23 +10,6 @@
 main:
   - title: "Resume"
     url: /cv/
-    
+
   - title: "Projects"
     url: /portfolio/
-        
-  - title: "Publications"
-    url: /publications/
-
-  - title: "Talks"
-    url: /talks/    
-
-  - title: "Lecturing"
-    url: /teaching/    
-    
-#
-#  - title: "Guide"
-#    url: /markdown/
-#
-#  - title: "Blog Posts"
-#    url: /year-archive/
-#   

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -36,6 +36,15 @@
       {% if author.email %}
         <li><a href="mailto:{{ author.email }}"><i class="fas fa-fw fa-envelope icon-pad-right" aria-hidden="true"></i>{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</a></li>
       {% endif %}
+      {% if author.linkedin %}
+        <li><a href="https://www.linkedin.com/in/{{ author.linkedin }}"><i class="fab fa-fw fa-linkedin icon-pad-right" aria-hidden="true"></i>LinkedIn</a></li>
+      {% endif %}
+      {% if author.github %}
+        <li><a href="https://github.com/{{ author.github }}"><i class="fab fa-fw fa-github icon-pad-right" aria-hidden="true"></i>GitHub</a></li>
+      {% endif %}
+      {% if author.googlescholar %}
+        <li><a href="{{ author.googlescholar }}"><i class="ai ai-google-scholar icon-pad-right"></i>Google Scholar</a></li>
+      {% endif %}
 
       <!-- Font Awesome and Academicons icons / Academic websites -->
       {% if author.academia %}
@@ -44,9 +53,6 @@
       {% if author.arxiv %}
         <li><a href="{{ author.arxiv }}"><i class="ai ai-arxiv ai-fw icon-pad-right"></i>arXiv</a></li>
       {% endif %}      
-      {% if author.googlescholar %}
-        <li><a href="{{ author.googlescholar }}"><i class="ai ai-google-scholar icon-pad-right"></i>Google Scholar</a></li>
-      {% endif %}
       {% if author.semantic %}
         <li><a href="{{ author.semantic }}"><i class="ai ai-semantic-scholar ai-fw icon-pad-right"></i>Semantic Scholar</a></li>
       {% endif %}
@@ -76,9 +82,6 @@
       {% if author.dribbble %}
         <li><a href="https://dribbble.com/{{ author.dribbble }}"><i class="fab fa-fw fa-dribbble icon-pad-right" aria-hidden="true"></i>Dribbble</a></li>
       {% endif %}      
-      {% if author.github %}
-        <li><a href="https://github.com/{{ author.github }}"><i class="fab fa-fw fa-github icon-pad-right" aria-hidden="true"></i>GitHub</a></li>
-      {% endif %}
       {% if author.kaggle %}
         <li><a href="https://kaggle.com/{{ author.kaggle }}"><i class="fab fa-fw fa-kaggle icon-pad-right" aria-hidden="true"></i>Kaggle</a></li>
       {% endif %}      
@@ -113,9 +116,6 @@
       {% endif %}      
       {% if author.lastfm %}
         <li><a href="https://last.fm/user/{{ author.lastfm }}"><i class="fab fa-fw fa-lastfm icon-pad-right" aria-hidden="true"></i>Last.fm</a></li>
-      {% endif %}      
-      {% if author.linkedin %}
-        <li><a href="https://www.linkedin.com/in/{{ author.linkedin }}"><i class="fab fa-fw fa-linkedin icon-pad-right" aria-hidden="true"></i>LinkedIn</a></li>
       {% endif %}      
       {% if author.mastodon %}
         <li><a href="{{ author.mastodon }}"><i class="fab fa-fw fa-mastodon icon-pad-right" aria-hidden="true"></i>Mastodon</a></li>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -8,24 +8,22 @@ redirect_from:
   - /about.html
 ---
 
-Using simulation to understand and optimize complex engineering systems
+Turning complex system behavior into actionable engineering decisions
 
 # About
 
-I am a Senior Analysis Engineer specializing in modeling and simulation of drivetrain and energy systems.
+I am a Senior Analysis Engineer focused on drivetrain and energy systems.
 
-My work focuses on understanding the behavior of complex mechanical systems and supporting engineering decisions through physics-based modeling, numerical simulation, and data analysis.
+I build physics-based models and simulation workflows that help teams evaluate performance, risk, and trade-offs before hardware decisions are locked in. My work is centered on turning complex technical behavior into clear, decision-oriented engineering insight.
 
-I have developed simulation frameworks for hybrid and conventional truck powertrains, as well as reduced-order models for wind turbine drivetrains. These models are used to evaluate system performance, analyze trade-offs, and support design and operational strategies.
+Across wind and heavy-duty vehicle applications, I have developed and applied models for hybrid and conventional powertrains, gearbox dynamics, and system-level energy performance. I use these models to compare design options, test control strategies, and support cost and feasibility decisions.
 
-My approach combines engineering reasoning with computational tools to bridge the gap between detailed physical models and practical, decision-oriented analysis.
+My approach combines first-principles engineering, numerical simulation, and practical analysis to deliver results that are technically rigorous and useful in product development.
 
 # Background
 
-I hold a PhD in Mechanical Engineering from DTU (Technical University of Denmark), with earlier degrees from UFRN (Brazil).
+I hold a PhD in Mechanical Engineering from DTU (Technical University of Denmark), with prior MSc and BSc degrees from UFRN (Brazil).
 
-My research background is in nonlinear mechanics, where I combined experimental, numerical, and analytical methods to study vibro-impact systems and understand differences between models and real-world behavior.
+I started in nonlinear mechanics, where I combined experiments, analytical methods, and numerical simulation to evaluate model reliability in vibro-impact systems. This foundation in model validation and uncertainty translated directly into applied industrial work.
 
-Following my PhD, I worked on drivetrain systems for offshore wind turbines, developing modeling approaches for gearbox dynamics, fatigue, and reduced-order simulation. I later transitioned to hybrid truck powertrains, applying system-level modeling to analyze energy usage, efficiency, and techno-economic performance.
-
-This progression reflects a shift from fundamental mechanics to applied engineering problems in energy and machinery systems.
+Since then, I have worked on offshore wind and hybrid truck powertrain challenges, including drivetrain dynamics, fatigue-related analysis, reduced-order modeling, and techno-economic studies. Over time, my role evolved from research-heavy work to engineering analysis that directly supports product and technology decisions.

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -119,16 +119,25 @@ Conducted experimental, numerical, and analytical research on nonlinear mechanic
 
 ---
 
-## Publications
-  <ul>{% for post in site.publications reversed %}
-    {% include archive-single-cv.html %}
-  {% endfor %}</ul>
+## Additional Experience
 
----
+### Publications
+<ul>{% for post in site.publications reversed %}
+  {% include archive-single-cv.html %}
+{% endfor %}</ul>
 
-## Professional Service
+### Talks
+<ul>{% for post in site.talks reversed %}
+  {% include archive-single-talk-cv.html %}
+{% endfor %}</ul>
+
+### Teaching
+<ul>{% for post in site.teaching reversed %}
+  {% include archive-single-cv.html %}
+{% endfor %}</ul>
+
+### Service
 - Reviewer for international conferences and journals (e.g., [Journal of Vibration and Control](http://jvc.sagepub.com/) and [COBEM 2019](https://eventos.abcm.org.br/cobem2019/))
-
 
 ## Additional Information
 **Languages:**

--- a/_pages/portfolio.html
+++ b/_pages/portfolio.html
@@ -7,48 +7,47 @@ author_profile: true
 
 {% include base_path %}
 
-# Selected Engineering Projects
+<h1>Engineering Portfolio</h1>
 
-I use physics-based modeling, simulation, and data analysis to understand complex machinery systems and support engineering decisions.
+<p>
+  I use modeling, simulation, and decision-oriented analysis to support drivetrain and energy-system engineering.
+</p>
 
-My portfolio focuses on three recurring themes:
+<hr />
 
-- **System-level simulation** for energy and drivetrain systems  
-- **Model reduction and scaling** for practical engineering workflows  
-- **Model validation** against experimental or high-fidelity results  
+<h2>Featured Projects</h2>
 
----
+<h3><a href="{{ base_path }}/portfolio/truck_sim">Hybrid and Conventional Truck Powertrain Simulation</a></h3>
+<p>
+  System-level simulation of combustion, electric, and hybrid truck powertrains to evaluate energy usage,
+  control strategies, and techno-economic performance.
+</p>
+<p><strong>Focus:</strong> powertrain modeling · control strategy analysis · TCO/ROI · scenario comparison<br />
+<strong>Tools:</strong> MATLAB · Simulink · Python · Excel</p>
 
-## Featured Projects
+<hr />
 
-### [Hybrid and Conventional Truck Powertrain Simulation]({{ base_path }}/portfolio/truck_sim)
+<h3><a href="{{ base_path }}/portfolio/down_scaling">Down-Scaled Modeling of Wind Turbine Gearboxes</a></h3>
+<p>
+  Scaling methodology for wind turbine gearbox models that preserves safety factors and dynamic behavior
+  for efficient test and development workflows.
+</p>
+<p><strong>Focus:</strong> gearbox scaling · drivetrain dynamics · reduced-order modeling · ISO 6336<br />
+<strong>Tools:</strong> MATLAB · KISSsoft · Simpack · COM interface</p>
 
-System-level simulation of combustion, electric, and hybrid truck powertrains to evaluate energy usage, control strategies, and techno-economic performance.
+<hr />
 
-**Focus:** powertrain modeling · TCO/ROI · energy flow · system optimization  
-**Tools:** MATLAB · Simulink · Python · Excel  
+<h3><a href="{{ base_path }}/portfolio/vibro_impact">Vibro-Impact Modeling, Design of Experiments, and Model Validation</a></h3>
+<p>
+  Integrated analytical, numerical, and experimental investigation of nonlinear vibro-impact behavior to
+  select fit-for-purpose models.
+</p>
+<p><strong>Focus:</strong> nonlinear dynamics · design of experiments · model comparison · validation<br />
+<strong>Tools:</strong> MATLAB · Maple · dSPACE/ControlDesk</p>
 
----
+<hr />
 
-### [Down-Scaled Modeling of Wind Turbine Gearboxes]({{ base_path }}/portfolio/down_scaling)
-
-Methodology for scaling wind turbine gearboxes while preserving structural integrity, safety factors, and dynamic behavior.
-
-**Focus:** drivetrain dynamics · gearbox scaling · reduced-order modeling · ISO 6336  
-**Tools:** MATLAB · KISSsoft · Simpack · COM interface  
-
----
-
-### [Modeling and Experimental Validation of Nonlinear Systems]({{ base_path }}/portfolio/vibro_impact)
-
-Comparison and validation of analytical and numerical models against experimental vibro-impact data to understand nonlinear mechanical behavior.
-
-**Focus:** model validation · nonlinear dynamics · experimental testing · simulation reliability  
-**Tools:** MATLAB · dSPACE/ControlDesk · analytical methods  
-
----
-
-## All Portfolio Items
+<h2>All Portfolio Items</h2>
 
 {% for post in site.portfolio %}
   {% include archive-single.html %}

--- a/_portfolio/down_scaling.md
+++ b/_portfolio/down_scaling.md
@@ -1,55 +1,50 @@
 ---
 title: "Down-Scaled Modeling of Wind Turbine Gearboxes"
-excerpt: "Reduced-order gearbox models preserving safety factors and dynamic behavior across scales"
+excerpt: "Case study: preserving safety factors and drivetrain dynamics across gearbox scales"
 collection: portfolio
 permalink: /portfolio/down_scaling
 ---
 
-## Down-Scaled Modeling of Wind Turbine Gearboxes
+## Case Study: Down-Scaled Modeling of Wind Turbine Gearboxes
 
 ### Purpose
-Testing full-scale wind turbine gearboxes is expensive and logistically challenging.  
-This project focused on developing a methodology to create down-scaled gearbox models that preserve both structural integrity and dynamic behavior, enabling more efficient testing and analysis.
+Full-scale wind turbine gearbox testing is expensive and difficult to iterate quickly.  
+This work developed a structured down-scaling method to create compact gearbox models while preserving key design and dynamic characteristics required for engineering decisions.
 
 ### Approach
-I developed a structured scaling methodology for multi-stage wind turbine gearboxes, ensuring that key characteristics are maintained across different power levels:
+The workflow separates scaling targets by function and constraint, then applies parameter scaling with iterative checks:
 
-- Gear safety factors (based on ISO 6336)  
-- Resonance and frequency distribution  
-- Structural and dynamic consistency  
+- Structural integrity targets (gear safety factors using ISO 6336)
+- Dynamic targets (resonance distribution and drivetrain response)
+- Practical design constraints for manufacturability and testability
 
-The scaling process separates parameters based on their influence on:
-- Mechanical integrity  
-- Dynamic response  
-
-A step-by-step procedure was implemented to compute appropriate scaling factors and allow fine-tuning of the resulting designs.
+A repeatable, step-by-step process was implemented to compute scale factors, update geometry and loading, and verify behavior at each iteration.
 
 <figure>
   <img src="{{site.url}}/images/projects/DT_comparison.png" alt="Cross-scale gearbox comparison"/>
   <figcaption>
-  Wind turbine gearboxes across scales (5000 kW to 0.5 kW) with preserved safety factors and dynamic characteristics.
+  Wind turbine gearboxes across scales (5000 kW to 0.5 kW) with matched safety factors and comparable dynamic signatures.
   </figcaption>
 </figure>
 
 ### Key Results
-- Achieved gearbox models with **similar safety factors and resonance distribution** (within ~5% deviation) across multiple scales  
-- Enabled realistic representation of large-scale drivetrain behavior using compact test setups  
-- Provided a systematic framework for scaling complex multi-stage gear systems  
+- Reproduced safety factors and resonance trends with deviations around 5% across evaluated scales
+- Reduced dependence on full-scale test infrastructure for early validation work
+- Established a reusable method for scaling multi-stage gearbox concepts
 
 ### Engineering Value
-This work enables:
-- Cost-effective experimental testing of wind turbine drivetrains  
-- Faster iteration in gearbox design and validation  
-- Improved understanding of dynamic behavior without full-scale infrastructure  
+- Enables faster concept screening for drivetrain architectures
+- Supports lower-cost validation planning and risk reduction
+- Improves confidence when extrapolating scaled-test results to larger systems
 
 ### Implementation
-- Gear safety factors evaluated using KISSsoft (ISO 6336)  
-- Scaling and optimization implemented in MATLAB  
-- Automated workflow using COM interface between MATLAB and KISSsoft  
-- Object-oriented structure for modular and reusable modeling  
+- Safety factor evaluation in KISSsoft (ISO 6336)
+- Scaling and optimization logic in MATLAB
+- Automated data exchange between MATLAB and KISSsoft via COM interface
+- Modular object-oriented structure to support reuse across cases
 
 ### Tools
-MATLAB · KISSsoft · Simpack (context) · COM interface integration
+MATLAB · KISSsoft · Simpack (context models) · COM automation
 
 ### References
-[**Rebouças** and Nejad, 2020)](/publication/A3)
+[**Rebouças** and Nejad, 2020](/publication/A3)

--- a/_portfolio/vibro_impact.md
+++ b/_portfolio/vibro_impact.md
@@ -1,56 +1,48 @@
 ---
-title: "Modeling and Experimental Validation of Nonlinear Systems"
-excerpt: "Selecting, validating, and applying models to understand real-world mechanical system behavior"
+title: "Vibro-Impact Modeling, Design of Experiments, and Model Validation"
+excerpt: "Integrated case study combining model development, experimental design, and model comparison"
 collection: portfolio
 permalink: /portfolio/vibro_impact
 ---
 
-## Modeling and Experimental Validation of Nonlinear Systems
+## Vibro-Impact Modeling, Design of Experiments, and Model Validation
 
 ### Purpose
-Engineering problems often have multiple competing models, each with different assumptions, accuracy, and computational cost.  
-This project focused on identifying the most suitable modeling approaches for vibro-impact systems and validating them against experimental data.
+Vibro-impact systems are sensitive to modeling assumptions, and different model types can produce very different predictions.  
+This project unified model development, design of experiments, and model comparison to determine which approaches are reliable for engineering use.
 
 ### Approach
-I combined analytical, numerical, and experimental methods to evaluate different modeling strategies:
+I combined three complementary workstreams:
 
-- Compared commonly used impact models (e.g., coefficient of restitution, contact force models)  
-- Designed and conducted experiments to reproduce different impact scenarios  
-- Correlated simulation and analytical predictions with experimental observations  
+1. **Model development:** analytical and numerical formulations for impact behavior
+2. **Design of experiments:** test matrix definition for stiffness, gap, and excitation variations
+3. **Model comparison:** direct cross-checks between analytical, numerical, and measured responses
 
 <figure>
-  <img src="{{site.url}}/images/projects/graphical_abstract.jpg" alt="Experimental setup and results comparison"/>
+  <img src="{{site.url}}/images/projects/graphical_abstract.jpg" alt="Experimental setup and model comparison"/>
   <figcaption>
-  Experimental setup and comparison of analytical, numerical, and experimental results for different impact models.
+  Experimental setup and comparison of analytical, numerical, and measured responses for vibro-impact behavior.
   </figcaption>
 </figure>
 
-### Experimental Work
-The experimental setup was designed and iteratively refined to investigate the influence of:
+### Key Results
+- Identified where simplified impact models are acceptable and where they are not
+- Quantified mismatch patterns between simulation and experiments across operating regions
+- Built a reproducible evaluation structure for selecting fit-for-purpose models
 
-- Contact stiffness  
-- Gap size  
-- Excitation frequency and amplitude  
+### Engineering Value
+- Supports faster model selection during early engineering studies
+- Reduces decision risk by exposing model limits before deployment
+- Improves confidence in simulation-backed recommendations
 
-This hands-on work involved:
-- Instrumentation and data acquisition (sensors, actuators, signal conditioning)  
-- Troubleshooting and tuning of experimental systems  
-- Validation of model assumptions against measured data  
-
-### Key Insights
-- Identified applicability ranges for different modeling approaches depending on system characteristics (e.g., contact duration)  
-- Demonstrated limitations of commonly used models when compared to real-world behavior  
-- Showed how analytical and numerical methods can explain experimentally observed nonlinear dynamics  
-
-### Engineering Relevance
-This work supports:
-- Selection of appropriate models for simulation and analysis  
-- Validation of simulation results against real systems  
-- Troubleshooting unexpected dynamic behavior in machinery  
-- Improving confidence in engineering decisions based on models  
+### Implementation
+- Instrumented and tuned an experimental rig for controlled impact scenarios
+- Ran parameterized simulations for multiple impact model variants
+- Compared results using consistent metrics in time and frequency domains
+- Refined model assumptions based on observed discrepancies
 
 ### Tools
-MATLAB · Maple (Analytical methods/perturbation techniques) · Experimental setup (dSPACE/ControlDesk)
+MATLAB · Maple (analytical methods) · dSPACE/ControlDesk · Experimental DAQ and instrumentation
 
 ### References
-[(**Rebouças**, 2018)]({% link phd_thesis.md %})
+[**Rebouças**, 2018]({% link phd_thesis.md %})


### PR DESCRIPTION
### Motivation
- Refresh and clarify site content and portfolio presentation to better reflect decision-oriented engineering work and project detail. 
- Consolidate author social links and remove redundant/unused profile fields for a cleaner author card. 
- Simplify header navigation to prioritize Resume and Projects.

### Description
- Rewrote the About page (`_pages/about.md`) for clearer, decision-focused messaging and updated academic background phrasing. 
- Reworked the Portfolio landing (`_pages/portfolio.html`) and individual portfolio items (`_portfolio/*.md`) into a cleaner, structured HTML/Markdown presentation with new headings, summaries, and project detail blocks. 
- Reorganized the CV page (`_pages/cv.md`) to add `Talks`, `Teaching`, and `Service` sections and moved `Publications` under `Additional Experience`. 
- Updated the author profile include (`_includes/author-profile.html`) to deduplicate and reorder social links and prominently surface `LinkedIn`, `GitHub`, and `Google Scholar`. 
- Removed several author fields from `_config.yml` (legacy handles) and adjusted the navigation order in `_data/navigation.yml` to remove secondary links (`Publications`, `Talks`, `Lecturing`) from the header.

### Testing
- Performed a local site build with `jekyll build`, which completed successfully. 
- Ran link/content checks with `htmlproofer` against the generated site, which reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6eb425e88333bb2554f5de754d8f)